### PR TITLE
A51 Support for TWRP (WIP)

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -16,11 +16,11 @@ TARGET_CPU_VARIANT := cortex-a53
 TARGET_CPU_SMP := true
 
 # Secondary Architecture
-TARGET_2ND_ARCH := arm
+TARGET_2ND_ARCH := arm64
 TARGET_2ND_ARCH_VARIANT := armv8-a
-TARGET_2ND_CPU_ABI := armeabi-v7a
-TARGET_2ND_CPU_ABI2 := armeabi
-TARGET_2ND_CPU_VARIANT := cortex-a53
+TARGET_2ND_CPU_ABI := arm64-v8a
+TARGET_2ND_CPU_ABI2 :=
+TARGET_2ND_CPU_VARIANT := cortex-a73
 
 # Kernel
 BOARD_KERNEL_CMDLINE := androidboot.selinux=permissive

--- a/recovery.fstab
+++ b/recovery.fstab
@@ -3,14 +3,14 @@
 #product         /product        ext4            ro,errors=panic         wait,avb,logical,first_stage_mount
 #odm             /odm            ext4            ro,errors=panic         wait,avb,logical,first_stage_mount
 
-/system_root    ext4    /dev/block/platform/13520000.ufs/by-name/system 	flags=display="System";backup=0
-/system_image   emmc    /dev/block/platform/13520000.ufs/by-name/system 	flags=backup=1;flashimg
-/vendor		ext4	/dev/block/platform/13520000.ufs/by-name/vendor 	flags=backup=0
-/vendor_image	emmc	/dev/block/platform/13520000.ufs/by-name/vendor		flags=backup=1;flashimg
-/product	ext4	/dev/block/platform/13520000.ufs/by-name/product 	flags=backup=1;display="Product"
-/product_image	emmc	/dev/block/platform/13520000.ufs/by-name/product 	flags=backup=1;flashimg;display="Product Image (CSC)"
-/odm		ext4	/dev/block/platform/13520000.ufs/by-name/odm 		flags=backup=0
-/odm_image	emmc	/dev/block/platform/13520000.ufs/by-name/odm		flags=backup=1;flashimg
+/system_root    ext4    /dev/block/dm-4                                         flags=display="System";backup=0
+/system_image   emmc    /dev/block/dm-4                                         flags=backup=1;flashimg
+/vendor		ext4	/dev/block/dm-5                                         flags=backup=0
+/vendor_image	emmc	/dev/block/dm-5                                         flags=backup=1;flashimg
+/product	ext4	/dev/block/dm-6                                         flags=backup=1;display="Product"
+/product_image	emmc	/dev/block/dm-6                                         flags=backup=1;flashimg;display="Product Image (CSC)"
+/odm		ext4	/dev/block/dm-7                                         flags=backup=0
+/odm_image	emmc	/dev/block/dm-7                                         flags=backup=1;flashimg
 
 /modem		emmc	/dev/block/platform/13520000.ufs/by-name/radio		flags=backup=1;display="Modem Firmware"
 /boot           emmc    /dev/block/platform/13520000.ufs/by-name/boot


### PR DESCRIPTION
Brought fstab table in line with Samsung's stock recovery (mounting /system & /vendor should be fixed now) 

Configured our second CPU variable to match device spec as we have 4x cortex a53 and 4x cortex a73 cores with the 9611 chipset. 